### PR TITLE
loosen slop dependency

### DIFF
--- a/pry-remote-reloaded.gemspec
+++ b/pry-remote-reloaded.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_dependency "slop", "~> 3.0"
+  s.add_dependency "slop", ">= 3.0"
   s.add_dependency "pry",  ">= 0.14"
 
   s.executables = ["pry-remote"]


### PR DESCRIPTION
I'm unable to bundle this in some apps that also use Gruf for GRPC, due to Gruf requiring 4.x of slop. It seems that the usage here will still work the same, and this would help our dev envs. Thanks 🙏 