### PR TITLE
Allow configuring URI instead of host and port

### DIFF
--- a/pry-remote-reloaded.gemspec
+++ b/pry-remote-reloaded.gemspec
@@ -4,7 +4,7 @@
 Gem::Specification.new do |s|
   s.name = "pry-remote-reloaded"
 
-  s.version = "1.2.0"
+  s.version = "2.0.0"
 
   s.summary     = "Connect to Pry remotely"
   s.description = "Connect to Pry remotely using DRb"


### PR DESCRIPTION
This enables use of non-TCP sockets, such as UNIX domain sockets (see https://github.com/ruby/drb/blob/v2.2.1/lib/drb/unix.rb)

It's a breaking change but that seems acceptable for a tool of this kind. The change could also be made backward compatible but in my opinion that's not vital. I think a clean and unambiguous API/CLI is more important, wdyt?
