### PR TITLE
Allow configuring URI instead of host and port.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## next
+
+* Allow configuring server URI instead of host and port (#4)
+  * The CLI still allows to configure server/port, but allows to pass the
+    URI which takes precedence
+  * This is a breaking change for `Object#remote_pry` as its signature is
+    changed to keyword arguments (`uri:, **options`)
+  * The `PryRemoteReloaded::Server.new` and `PryRemoteReloaded::Server.run`
+    signatures also changed to keyword arguments,
+    but thats only for internal use
+
 ## 2.0.0 (205-08-19)
 
 * Upgraded to slop 4.x (#3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pry-remote-reloaded (1.2.0)
+    pry-remote-reloaded (2.0.0)
       drb (~> 2.2)
       pry (>= 0.15)
       slop (~> 4.10)

--- a/bin/test-server
+++ b/bin/test-server
@@ -19,5 +19,8 @@ end
 obj = Test.new
 
 loop do
-  binding.remote_pry
+  binding.remote_pry # defaults to druby://
+
+  # use with: $ pry-remote -u 'drbunix:/tmp/pry.socket'
+  # binding.remote_pry(uri: 'drbunix:/tmp/pry.socket')
 end

--- a/pry-remote-reloaded.gemspec
+++ b/pry-remote-reloaded.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |s|
   s.files |= Dir["*.md"]
   s.files << "LICENSE"
 
+  s.required_ruby_version = '>= 3.1'
+
   s.require_paths = ["lib"]
 
   s.add_dependency "slop", "~> 4.10"


### PR DESCRIPTION
See original: https://github.com/Jack12816/pry-remote-reloaded/pull/2